### PR TITLE
Fix for Rails 3 users

### DIFF
--- a/app/models/shortener/shortened_url.rb
+++ b/app/models/shortener/shortened_url.rb
@@ -10,7 +10,12 @@ class Shortener::ShortenedUrl < ActiveRecord::Base
   # exclude records in which expiration time is set and expiration time is greater than current time
   scope :unexpired, -> { where(arel_table[:expires_at].eq(nil).or(arel_table[:expires_at].gt(::Time.current.to_s(:db)))) }
 
-  attr_accessor :custom_key
+  if Rails::VERSION::MAJOR > 3
+     attr_accessor :custom_key
+  else
+    # since rails 3 doesn't support strong parameters, need to white-list these params
+     attr_accessible :unique_key, :expires_at, :custom_key
+  end
 
   # ensure the url starts with it protocol and is normalized
   def self.clean_url(url)


### PR DESCRIPTION
Rails 3 is super-old, but, due to it's lack of strong parameter support introduced in rails 4, this throws a mass assignment error unless params are whitelisted. This patch checks the rails major version and whitelists those params for Rails 3 only.